### PR TITLE
Add data-set-metadata file

### DIFF
--- a/metadata/data-set-metadata.Rmd
+++ b/metadata/data-set-metadata.Rmd
@@ -1,0 +1,953 @@
+---
+title: "Metadata for data sets used in the Grande Ronde Life Cycle Model"
+output:
+  html_document:
+    toc: yes
+    toc_depth: 2
+    toc_float: yes
+---
+
+```{r setup, include=FALSE}
+knitr::opts_chunk$set(echo = FALSE)
+library(knitr)
+# library(kable)
+library(kableExtra)
+library(ggplot2)
+library(dplyr)
+```
+
+# Data set summary
+```{r}
+time <- read.csv("//fweou/data/GR_Chinook_LCM/lcm-data-prep/time-series-info-datasets.csv")
+time[which(time$data.set=="adult-indiv-weir" & time$population=="MIN"),
+     c("first.year", "last.year")] <- "--"
+
+time %>%
+  select(life.stage, origin, data.set, statistic, population, everything()) %>%
+  kable(col.names = c("Life stage", "Origin", "Data set", "Statistic", "Population", "Num. years", "First year", "Last year", "Notes"),
+        align = "l") %>%
+  column_spec(column=1:2, width="2em") %>%
+  column_spec(column=3, bold=T, background = "#91D1C233", width="13em") %>%
+  column_spec(column=4:5, width="2em") %>%
+  column_spec(column=6, width="2em") %>%
+  column_spec(column=c(7,8), width="5em") %>%
+  column_spec(column=9, width="3in") %>%
+  collapse_rows(columns = c(1,2,3,4),
+                target = 3
+                ) %>%  #this one controls grouping and lines
+  kable_styling(bootstrap_options = ("striped"),
+                full_width=FALSE, 
+                position="left", 
+                font_size=10)
+  
+```
+
+# Abbreviations
+Acronyms and other abbreviations used in this document:
+
+- **BY:** brood year - year when a cohort of fish was spawned
+
+- **BON:** Bonneville Dam (the farthest downstream of the mainstem dams)
+
+- **CSS:** Comparative Survival Study
+
+- **CTUIR:** Confederated Tribes of the Umatilla Indian Reservation
+
+- **CWT:** coded wire tag 
+
+- **LGR:** Lower Granite Dam (the farthest upstream of the mainstem dams encountered by Grande Ronde fish)
+
+- **NPT:** Nez Perce Tribe
+
+- **ODFW:** Oregon Department of Fish and Wildlife
+
+- **PIT:** passive integrated transponder
+
+- **RTR:** return to the river - describes the group of adult fish in a given year that return to the mouth of the natal tributary, before any losses to tributary harvest, weir removals, or prespawn mortality 
+
+- **RY:** return year - year when a group of adult fish return and spawn. Because adults return at a variety of ages, the adults in a given return year comprise multiple brood years of origin
+
+# Data set metadata {.tabset .tabset-dropdown}
+
+## Juvenile: juv-abundance
+
+### Citation
+Gibson PP, Drascic FJ, Haynes DR, McMichael GA, Ofiara JA, Raines MA, and Warnock CR. 2023. Investigations into the life history of naturally produced Chinook salmon and summer steelhead in the Grande Ronde River subbasin. Annual Report BPA Project #1992-026-04, Oregon Department of Fish and Wildlife, La Grande, OR. URL: https://nrimp.dfw.state.or.us/DataClearinghouse/default.aspx?p=202&XMLname=42707.xml
+
+### Description
+This data set describes the *abundance* of natural origin juvenile Chinook observed passing rotary screw traps as the fish move downstream out of spawning areas in the headwaters. 
+
+Abundance is measured using rotary screw traps, located near the lower extent of spawning in each population. Generally the screw traps operate during 
+two seasons, corresponding to the primary periods of fish movement: fall (early migrants) and spring (late migrants). In general ice cover (winter) and high temperatures (summer) prevent the traps from operating year-round, although the trap on the Lostine River is usually able to operate through most of the winter. Very few fish are caught during this winter period. 
+
+Mark-recapture trials for measuring the efficiency of the screw traps are conducted by releasing marked fish above the trap throughout the sampling season (Volkhardt et al. 2007). Up through migration year 2019, abundance was calculated using the simple Peterson estimator, with no attempt to account for missed trapping days. For migration years 2020 and later, abundance was estimated using a generalized additive model with a penalized spline smooth term, which smooths the curve for estimated daily abundance passing the trap and interpolates for missed trapping days during the sampling season (Duarte and Peterson 2020). For all years, variance of the abundance estimates was estimated using the one-sample bootstrap method (Thedinga et al. 1994).  
+Because rotary screw traps only count fish moving downstream past the trap, they cannot account for fish that were spawned downstream of the trap. In order to account for the contribution of any downstream spawning to juvenile production, in this data set the estimates of of the number of fish passing the screw traps are expanded by the ratio of the number of redds (from the appropriate brood year) counted above the screw trap to the total number of redds counted in the population for that brood year, both above and below the trap.   
+
+**Years of data:** 29 (BY 1992 - 2020)
+
+- CAT: 28 years (BY 1993-2020)
+
+- LOS: 25 years (BY 1995-2020; missing BY 2002)
+
+- MIN: 22 years (BY 1999-2020)
+
+- UGR: 28 years (BY 1992-2020; missing part of BY 2019)
+
+
+### Fields
+```{r abund_fields_tbl}
+
+juv_length_fields_tbl <- data.frame(
+  Field = c("population", "brood_year",	"mig_year",	"season",	
+            "abund_est", "abund_se", "expansion_factor",
+            "abund_notes"),
+  Description = c(
+    "`CAT` = Catherine Creek; `LOS` = Lostine River; `MIN` = Minam River; `UGR` = Upper Grande Ronde River.", 
+    "Calendar year when the cohort of fish was spawned.",
+    "Calendar year when the cohort of fish migrated out to the ocean; equivalent to `[brood_year] + 2`.",
+    "Indicates the season when fish migrated downstream past the screw trap. `fall` fish (also known as 'early migrants') move out of their headwater spawning locations in the fall and spend the winter downstream of the smolt trap; while `spring` fish ('late migrants') spend the winter in the headwaters and move downstream past the smolt trap in the spring, on their way out to the mainstem Snake River and the ocean.",
+    "Estimated total number of fish that passed the screw trap over the course of the season, expanded by the ratio of redds counted upstream of the smolt trap to all redds counted in the population (`[expansion_factor]` ), to account for any spawning downstream of the traps.",
+    "Standard error associated with the abundance estimate, from a bootstrapped estimate of variance.",
+    "Ratio of the number of redds counted above the smolt trap to the total number of redds counted for the population, both above and below the smolt trap, in a given year. Estimated abundances of juveniles passing the smolt traps were divided by this ratio to get the expanded abundances reported here.",
+    "Comments on any specific limitations of the reported value."
+  )
+)
+
+kable(juv_length_fields_tbl) %>%
+  kable_styling(full_width = T, font_size = 10) %>%
+  column_spec(1, bold = T, border_right = T) %>%
+  column_spec(2) #, width = "30em"
+
+# source: http://haozhu233.github.io/kableExtra/awesome_table_in_html.html#column__row_specification
+```
+
+### Notes and limitations
+
+The primary limitation affecting migrant abundance estimates from screw traps is missed trapping days during the migration period: traps sometimes have to shut down for heavy debris loads, ice cover, or very high flows, and data may be unusable due to, for example, a log jamming the trap. In the pre-2019 abundance estimates, no attempt was made to account for these missed days, so the number and timing of missed days can strongly influence the total abundance estimate for the season. Additionally, any migrants that pass the trap before the start or after the end of trapping are not counted in the abundance estimates.  
+
+At the Catherine Creek trap site, substantial numbers of young-of-year are regularly observed moving downstream past the trap in late spring and early summer, with unknown numbers moving during the portion of the summer when the trap does not operate (due to high temperatures). These fish are not accounted for in the abundance estimates, which only count fish that move downstream later in the fall as early migrants, or in the following spring as late migrants.  Therefore the juvenile abundance estimates for Catherine Creek underestimate the true number of juvenile fish produced in that population, but the magnitude of this underestimate is not known. Although a few late-spring young-of-year are typically observed at the other screw trap sites, only Catherine Creek consistently sees large numbers of these fish. 
+
+During the spring when hatchery smolt are released, screw traps cannot operate continuously because the large numbers of hatchery origin fish can quickly overfill a trap and cause mortality.  Instead, systematic subsampling is often used to sample during hatchery release periods.  During subsampling, the traps are operated for the four hours immediately after twilight (this period corresponds to the time of day when the majority of fish movement typically occurs), and then shut down for the rest of the night.  In order to calibrate this subsampling, the trap is operated continuosly (24 hour sampling) before and after the subsample nights, but the number of wild fish caught during the four-hour subsample window are counted separately from the fish caught during the rest of the 24-hour period, in order to determine the proportion of the full 24-hour catch that was caught during the four-hour subsampling window. This proportion is used to expand the catch during subsample nights to the expected number of fish that would have been caught with 24 hours of continuous sampling. 
+
+Missing data: 
+
+- The Lostine River trap was not operated during migration year 2004 (BY 2002).
+
+- The Upper Grande Ronde River trap does not have an abundance estimate for fall 2021 (BY 2020; MY 2022) due to very limited trap operation time, and low fish numbers observed during the period of operation. There are also several other very uncertain abundance estimates from the UGR trap, again due to limited trap operation time and very low catch. 
+
+
+## Juvenile: juv-survival
+
+### Citation
+Gibson PP, Drascic FJ, Haynes DR, McMichael GA, Ofiara JA, Raines MA, and Warnock CR. 2023. Investigations into the life history of naturally produced Chinook salmon and summer steelhead in the Grande Ronde River subbasin. Annual Report BPA Project #1992-026-04, Oregon Department of Fish and Wildlife, La Grande, OR. URL: https://nrimp.dfw.state.or.us/DataClearinghouse/default.aspx?p=202&XMLname=42707.xml
+
+### Description
+This data set describes the estimated probability of *survival* for PIT-tagged natural origin juvenile Chinook parr and smolt from the time of tagging to arrival at Lower Granite Dam as smolt during the spring outmigration. Groups of juvenile Chinook (hereafter, "tag groups") are captured and tagged at several different locations and time periods during their early life history:
+
+- Fish in the **summer** tag group are actively captured (by snorkel-herding) throughout the rearing habitat above the screw trap, over the course of approximately one week during the summer (late July - August). These fish are captured as parr during their freshwater rearing summer, approximately nine months before their outmigration the following spring. 
+
+- Fish in the **fall** tag group ('early migrants') are passively captured at the rotary screw trap over the course of the fall movement period (September - November). 
+
+- Fish in the **winter** tag group are actively captured throughout the rearing habitat above the screw trap, over the course of approximately one week in early winter (usually early December). Because these fish are still upstream of the screw trap at the end of the fall movement period, all fish in the winter tag group display the 'late migrant' life history. There are no winter survival estimates for the Minam population. (The Minam is a wilderness river and access is very difficult during the winter.)
+
+- Fish in the **spring** tag group ('late migrants') are passively captured at the rotary screw trap over the course of the spring movement period (primarily March - April).
+
+Survival to Lower Granite Dam is estimated with a Cormack-Jolly-Seber model, using all detections at mainstem dams below Lower Granite as a pooled second survival interval. Probability of detection at Lower Granite Dam is estimated independently for each tag group.  Confidence intervals are calculated based on profile likelihood. 
+
+These survival estimates use all tagged fish that meet the following conditions:  
+
+- PIT-tagged during the correct season.
+
+- Not a recapture.
+
+- Target cohort - not known to be precocious or young of year. 
+
+**Years of data:** 
+
+* summer: 
+
+  + CAT: 30 years (BY 1991-2020)
+  
+  + LOS: 29 years (BY 1991-2020; no BY 1996)
+  
+  + MIN: 30 years (BY 1991-2020)
+  
+  + UGR: 17 years (BY 1991-1993, 2006, and 2008-2020)  
+
+* fall and spring: 
+
+  + CAT: 28 years (BY 1993-2020; no BY 2013 fall)
+  
+  + LOS: 25 years (BY 1995-2020; no BY 2002)
+  
+  + MIN: 22 years (BY 1999-2020)
+  
+  + UGR: 26 years (BY 1992-2020, with numerous missing estimates)
+
+* winter:
+
+  + CAT: 28 years (BY 1993-2020)
+  
+  + LOS: 26 years (BY 1995-2020)
+  
+  + MIN: 0 years *(no winter PIT-tagging in Minam population)*
+  
+  + UGR: 22 years (BY 1992-2020, with numerous missing estimates)
+
+
+### Fields
+```{r surv_fields_tbl}
+
+juv_surv_fields_tbl <- data.frame(
+  Field = c("population", "brood_year",	"mig_year",	"season",	
+            "n_tagged", "surv_est", "surv_ci_low", "surv_ci_high", "surv_se", 
+            "surv_notes"),
+  Description = c(
+    "`CAT` = Catherine Creek; `LOS` = Lostine River; `MIN` = Minam River; `UGR` = Upper Grande Ronde River.", 
+    "Calendar year when the cohort of fish was spawned.",
+    "Calendar year when the cohort of fish migrated out to the ocean; equivalent to `[brood_year] + 2`.",
+    "Indicates both the season when the fish were captured and tagged, and the method by which the fish were captured. `summer` and `winter` fish are actively captured by snorkel-herding throughout the rearing habitat, while `fall` and `spring` fish are passively captured in rotary screw traps.",
+    "Number of tagged fish used in the survival estimate.",
+    "Estimated probability of survival from the time of tagging to arrival at Lower Granite Dam as a smolt during the spring outmigration.",
+    "Lower bound of the 95% confidence interval for the survival estimate.",
+    "Upper bound of the 95% confidence interval for the survival estimate.",
+    "Standard error for the survival estimate. Generally calculated when sample size is too low to allow estimation of a 95% confidence interval.",
+    "Comments on any specific limitations of the reported survival estimate."
+  )
+)
+
+kable(juv_surv_fields_tbl) %>%
+  kable_styling(full_width = T, font_size = 10) %>%
+  column_spec(1, bold = T, border_right = T) %>%
+  column_spec(2) #, width = "30em"
+
+# source: http://haozhu233.github.io/kableExtra/awesome_table_in_html.html#column__row_specification
+```
+
+### Notes and limitations
+Precision of the survival estimates depends on the number of fish tagged (sample size), the probability of survival, and the probability of detection at Lower Granite Dam and at the other mainstem dams. Many of the calculated survival estimates have very wide confidence intervals for a combination of these reasons. In particular, detections downstream of Lower Granite Dam are often the rarest and most limiting piece of information for estimating survival. 
+
+These survival estimates are assumed to be representative of the full population (or specific portions of the population, such as early migrants for the fall rotary screw trap survival estimates). However, in practice the fish used to generate the survival estimates are not necessarily a representative sample of the population. First, fish must be at least 55 mm fork length in order to get PIT tagged; in years and river segments where many fish are smaller than this threshold, in practice it is only the larger portion of the population (at the time of tagging) that is being sampled. Second, when distributing PIT tags for the summer and winter tag groups, the goal is to roughly match the observed density and distribution of parr throughout the watershed. But, again, in practice this is not necessarily achieved due to access constraints, limited sampling time, and other logistical considerations. In practice large numbers of tags may go out in fish from a very limited spatial distribution, such that some stream reaches are over-represented and other reaches are under-represented in the tag group. 
+
+Missing data: 
+
+- There is a gap of nearly 15 years in the UGR summer survival estimates: there was no summer PIT tagging in the UGR population for brood years 1994-2005, nor in BY 2007.  
+
+- Most of the other populations and tag groups have occasional gaps in the time series of survival estimates due to low sample size of tags put out or too few detections downstream.  Missing estimates are especially common for the UGR population, where it is not uncommon to catch very few fish over the course of a season. 
+
+
+## Juvenile: juv-mean-length
+
+### Citation
+Gibson PP, Drascic FJ, Haynes DR, McMichael GA, Ofiara JA, Raines MA, and Warnock CR. 2023. Investigations into the life history of naturally produced Chinook salmon and summer steelhead in the Grande Ronde River subbasin. Annual Report BPA Project #1992-026-04, Oregon Department of Fish and Wildlife, La Grande, OR. URL: https://nrimp.dfw.state.or.us/DataClearinghouse/default.aspx?p=202&XMLname=42707.xml
+
+### Description
+
+This data set provides summary statistics, including *mean length* for all recorded length measurements of natural origin juvenile Chinook. All lengths describe **fork length in millimeters**, at the time of capture.
+
+Length statistics are reported by population, brood year, and tag group (summer, fall, winter, and spring), following the structure of the reported survival estimates. 
+
+In most seasons, not all fish captured and measured are PIT tagged. In fall and spring, at the rotary screw traps, this is primarily because there are often many more fish captured than there are available PIT tags.  In the summer, in recent years this is primarily because some fish are too small to PIT tag: since 2011, 55 mm fork length has been the minimum length for PIT tagging (fish smaller than 55 mm fork length may not be tagged), although in earlier years the minimum threshold was more variable (ranging from 50 mm to 65 mm, depending on the year). Additionally, in some earlier years (brood years 2000 - 2005), large numbers of fish were captured and measured as part of a mark-recapture population abundance estimate, creating a very large data set of length data from non-PIT fish.  In the winter, essentially all fish captured are PIT tagged; therefore there are no length data for non-PIT tagged fish (hereafter abbreviated as **NPT**) in winter, and the PIT length data set is assumed to provide an adequate sample of the population for the winter tag group.
+
+Because in some circumstances we may want statistics for PIT tagged fish only (ie, the set of fish used to generate the survival estimates; `[fish_subset] = "PIT"`), while in other circumstances we want statistics for the full population (`[fish_subset] = "all"`), this mean length data set reports both sets of statistics for each population/brood year/season (with a few exceptions). The PIT tagged fish used to calculate the mean lengths reported here are the same groups of fish that were used to generate the survival estimates.  
+
+Grande Ronde Chinook parr usually grow rapidly during summer, and the observed mean length of a population is strongly dependent on the day of year when fish are captured and measured. Because the summer tagging event occurs by active capture during a single week, and the timing of that week has varied among years, in the LCM we used a correction factor to account for the effect of tag date on observed population mean length. 
+
+From this full data set, the GR-LCM uses only the summer and spring tag groups (with `[fish_subset] = "all"`) for mean length and associated standard error.  
+
+**Source Data**
+
+These statistics summarize all available recorded length data from fish that meet the following conditions: 
+
+- Fish was captured above the rotary screw trap (or at it, for fall and spring fish); exclude any fish captured below the traps.
+
+- Fish was unmarked at the time of the length measurement; exclude all recaptures. 
+
+- Fish was not recorded as precocious or fry/young of year (i.e., a younger cohort than the target age class in a given year).
+
+- Fish was not captured as part of parr collection for captive broodstock (occurred only in CAT and LOS, for brood years 1994 and 1995). 
+
+- For fall and spring seasons (i.e., fish caught at the rotary screw traps), fish was caught between Sept 1 and Dec 15 (fall), or between Feb 15 and June 30 (spring). These date limits were applied to ensure some level of consistency and comparability among years with highly variable dates of trap operation. 
+
+**Years of data:** 
+
+* summer: 
+
+  + CAT: 30 years (BY 1991-2020)
+  
+  + LOS: 28 years (BY 1991-2020; no BY 1997 or 1998)
+  
+  + MIN: 30 years (BY 1991-2020)
+  
+  + UGR: 17 years (BY 1991-1993, 2006, and 2008-2020)  
+
+* spring: 
+
+  + CAT: 27 years (BY 1993-2020; no BY 1995)
+  
+  + LOS: 26 years (BY 1995-2020)
+  
+  + MIN: 22 years (BY 1999-2020)
+  
+  + UGR: 26 years (BY 1992-2020; no BY 1995, 1999, or 2007)
+
+
+### Fields
+```{r length_fields_tbl}
+
+juv_length_fields_tbl <- data.frame(
+  Field = c("fish_subset", "population", "brood_year",	"mig_year",	"season",	
+            "n_length",	"n_pit",	"n_npt",	
+            "len_mean",	"len_sd",	"len_min",	"len_max",	
+            "jday_med",	"rkm_mean"),
+  Description = c(
+    "Indicates whether the statistics in the record describe all measured fish (**`all`**) vs. only the PIT tagged fish (**`PIT`**). With a few exceptions, both sets of statistics (i.e., two rows of data) are provided for each population/year/season combination. Note that for winter season, `PIT` and `all` statistics are always the same, because typically there are almost no non-PIT tagged fish during winter and no undersize fish.",
+    "`CAT` = Catherine Creek; `LOS` = Lostine River; `MIN` = Minam River; `UGR` = Upper Grande Ronde River.", 
+    "Calendar year when the cohort of fish was spawned.",
+    "Calendar year when the cohort of fish migrated out to the ocean; equivalent to `[brood_year] + 2`.",
+    "Indicates both the season when the fish were captured/tagged, and the method by which the fish were captured. `summer` and `winter` fish are actively captured by snorkel-herding throughout the rearing habitat, while `fall` and `spring` fish are passively captured in rotary screw traps.",
+    "Number of length values included in the reported statistics. Equivalent to `[n_pit] + [n_npt]`.",
+    "A subset of `[n_length]`: number of PIT-tagged fish included in the reported length statistics. When `[fish_subset] = PIT`, `[n_pit]` is equal to `[n_length]`.",
+    "A subset of `[n_length]`: number of **not PIT-tagged** fish included in the reported length statistics. When `[fish_subset] = PIT`, `[n_npt]` is 0.",
+    "Mean length",
+    "Standard deviation of length values",
+    "Minimum recorded length",
+    "Maximum recorded length",
+    "Median Julian day (i.e., day of year; January 1 is Julian day 1, December 31 is Julian day 365 (or 366 in leap years)) when fish were tagged.  Julian day is a strong predictor of population average size for summer tagging - see below.",
+    "Average river kilometer from which fish were captured. River kilometer is recorded for each measured fish. River kilometers start at the mouth and count upstream, so higher numbers indicate higher position in the watershed. This metric provides an indicator of where in the watershed most fish were captured in a given year, because average fish size is partly a function of watershed position."
+  )
+)
+
+kable(juv_length_fields_tbl) %>%
+  kable_styling(full_width = T, font_size = 10) %>%
+  column_spec(1, bold = T, border_right = T) %>%
+  column_spec(2) #, width = "30em"
+
+```
+
+
+### Notes and limitations
+
+- Although the timing of summer fish capture and tagging has largely remained consistent within populations over the past ~15 years, in earlier years the timing was more variable; in general, summer tagging in 1993 through ~2005 tended to happen considerably later in the year than summer tagging in recent years.  Because fish usually grow rapidly during the summer, the median date of tagging (`[jday_med]`) is a strong predictor of population mean length. See also the discussion for the `juv-survival` data set.
+
+- Fish mean size at summer tagging also depends on watershed position (upstream reaches vs downstream reaches), although it explains less of the variaion in population mean size than day of tagging does. Fish in higher reaches tend to emerge later, and for a given date fish from the upper watershed tend to be substantially smaller than fish from the lower watershed. See also the discussion for the `juv-survival` data set.
+
+- For summers prior to 2001, recorded length data from undersize and other non-PIT-tagged fish (NPT) was sparse, inconsistent, and difficult to track down.  For brood years 1991 and 1996 - 1999 I never did  manage to find any recorded length data for summer NPT fish, and it is unclear to what extent this is because there simply were no undersize fish, vs these lengths were never recorded.  But examining length distributions from the years without NPT data shows that most distributions look complete, indicating that the available PIT tag length data are an acceptable measure of mean length for those sampling events; the exceptions are Lostine summer fish from brood years 1997 and (especially) 1998, where the distributions show a truncation at the 55 mm tagging threshold, indicating that the PIT tag length data set is missing the smaller fish in the population. Therefore Lostine summer brood years 1997 and 1998 are excluded from the `[fish_subset] = "all"` records. 
+
+- In a few cases in the summer data, individual lengths were recorded only for the first ~20 undersize fish, and thereafter undersize fish were only tallied.  In order to account for these fish in the length summary statistics, I simulated length values for these tallied undersize fish records by sampling from the data set of measured undersize lengths from a given population and year, limited to fish captured within a few river kilometers of the tallied fish.
+
+**Missing data**
+
+Some populations/years/seasons are missing or excluded from the mean length statistics. 
+
+* **No sampling:** Length data sets are entirely missing because no sampling occurred (trap did not operate or there was no snorkeling effort).
+
+  + fall- LOS MY04
+
+  + winter- UGR MY96-97, MY01-03, MY09
+
+  + summer- LOS MY98; UGR MY96-07, MY09
+
+  + spring - no fully missing data sets, but for LOS MY04 spring the trap ran only during the second half of the season (April 19 - June 18).
+  
+* **Non-tag data missing:** There are some population/seasons for which the data for non-tag fish was either not collected or has not yet been found. For the following population/season groups, length statistics are reported for `[fish_subset]=PIT` but not for `[fish_subset]=all` because we do not have adequate data for non-tag fish.
+
+  + summer - LOS MY99 and MY00. Non-tag data are missing and PIT length distributions show truncation effects due (presumably) to undersize fish.
+  
+  + fall and spring - CAT MY97. Trap catch and PIT tag numbers for this migration year indicate that there were substantial numbers of non-tagged fish,  but no non-tag data have been found.
+
+* **Inadequate sample size:** There were several population/season samples (primarily trap seasons at UGR), where sampling did occur, but the sampling was minimal/ineffective and caught so few fish that the available data do not provide an adequate sample of the population. A minimum sample size threshold of n=50 has been applied for reporting mean length: if there were fewer than 50 fish measured in a given season then mean length in that season is reported as `NA`, in place of reporting a mean based on a very small sample size.
+
+  + fall: UGR MY96-97, MY01, MY09, and MYY21
+  
+  + spring: UGR MY97, MY01, and MY09
+
+
+## Juvenile: hatchery-juv-releases
+
+### Citation
+Brandt EJ, Smith JD, Feldhaus JW, and Ruzycki JR. 2021. Lower Snake River Compensation Plan: Oregon spring Chinook salmon evaluation studies, 2019 Annual Progress Report. Oregon Department of Fish and Wildlife, La Grande, OR. URL:   https://www.fws.gov/sites/default/files/documents/2019%20ODFW%20CHS%20Annual%20Report.pdf
+
+### Description
+This data set describes *abundance* (number released) and *survival* (from the time of release to arrival at Lower Granite Dam) for hatchery-origin juvenile fish released into the Catherine Creek, Lostine, and Upper Grande Ronde populations. (There is no hatchery supplementation in the Minam population.) Fish are raised at the hatchery and released typically in the spring as age-2 smolt, at which point most fish immediately head downstream and out to the ocean.  In rare instances some of the hatchery fish for a given population and brood year are released earlier, as age-1 parr during the fall, and in this case the fish will overwinter in fresh water before migrating out to the ocean in the spring.  
+
+The abundance of hatchery fish released into each population each year is measured at the hatchery (based on estimates of fish per pound), and in the model we assumed that these numbers are known without error. 
+
+Survival to Lower Granite Dam is based on detections of PIT-tagged fish at mainstem dams; the survival point estimate is calculated using a Cormack-Jolly-Seber model, with all detections at mainstem dams below Lower Granite pooled into a second survival interval. Confidence intervals are calculated based on profile likelihood. The existing survival estimates for hatchery-origin juveniles are calculated separately for each hatchery raceway (each population of a given brood year at the hatchery is distributed among ~4 different raceways); different raceways may have different release dates or, in the earlier years of hatchery operations, contain fish from different hatchery programs (i.e., fish from the captive broodstock program vs. fish from the conventional program). In order to generate a single point estimate of survival for each population and each year for use in the life cycle model, we calculated a weighted average of the per-raceway survival estimates (weighted by the number of fish released from each raceway). 
+
+**Years of data:** 24 (brood years 1997-2020)
+
+For the LOS population, 1997 was the first brood year released; for the CAT and UGR populations, 1998 was the first brood year released. 
+
+### Fields
+```{r hatchery_juv_fields_tbl}
+
+hatchery_juv_fields_tbl <- data.frame(
+  Field = c("population", "brood_year",	"release_year",	
+            "n_smolt_released",	"surv_est", "surv_var", "surv_se", 
+            "includes_parr", "comments"),
+  Description = c(
+    "`CAT` = Catherine Creek; `LOS` = Lostine River; `MIN` = Minam River; `UGR` = Upper Grande Ronde River.", 
+    "Calendar year when the cohort of fish was spawned.",
+    "Calendar year when the cohort of fish was released. For standard smolt releases, fish are released in the spring and the release year is the same as the migration year (i.e., `[brood_year]` + 2); but in some cases fish are released as parr, in the calendar year prior to their outmigration year.",
+    "Total number of juvenile fish released. This total includes both smolt and parr, when applicable. The numbers of fish released are assumed to be known without error.",
+    "Estimated probability of survival from the time of release to arrival at Lower Granite Dam during the spring outmigration.",
+    "Variance for the survival point estimate.",
+    "Standard error for the survival point estimate.",
+    "Indicates whether the reported aggregate number released and survival point estimate include any parr releases. This value is usually `FALSE`, as hatchery fish are generally released as smolt.",
+    "Comments on any unusual features of the reported abundance and survival values."
+  )
+)
+
+kable(hatchery_juv_fields_tbl) %>%
+  kable_styling(full_width = T, font_size = 10) %>%
+  column_spec(1, bold = T, border_right = T) %>%
+  column_spec(2) #, width = "30em"
+
+```
+
+### Notes and limitations
+The conventional hatchery program for the Catherine Creek, Lostine River, and Upper Grande Ronde River populations, using endemic broodstock, was initiated with brood year 1997. Prior to this year, however, there were some inconsistent releases of hatchery fish (from out-of-basin broodstock) into UGR River and Catherine Creek in the 1980's and early 1990's. Most of these releases occurred before the time period being modeled by the LCM, but some of the 1990's releases could have produced returning adults during the time period being modeled. Additionally, releases of out-of-basin stock into the nearby Lookingglass Creek population through 2001 (brood year 1999) were known to result in high rates of straying as adults. Both of these events (returning adults from early UGR and CAT releases, as well as straying adults from Lookingglass releases) could have produced the hatchery-origin adults seen in the adult return data prior to the start of the conventional hatchery programs.  For simplicity, in the LCM all of these hatchery-origin adults from before the start of conventional hatchery programs are treated as "strays" (i.e., extra adults simply added into the population as needed, rather than being generated by spawners and moved through all the modeled processes).
+
+Most hatchery-origin juvenile fish are released in the spring as smolt (or pre-smolt), but there have been a few instances where part of the brood year was released as parr: Lostine brood years 2007, 2008, and 2020; and Upper Grande Ronde brood year 2000. Although rates of survival and eventual adult returns from parr releases are much lower than for equivalent smolt releases, specific survival estimates (to Lower Granite Dam) for these parr releases are included in the aggregate weighted average `[surv_est]` value, so the overall estimated of number of smolt arriving at Lower Granite Dam (i.e., smolt equivalents) for a given population and brood year using the aggregate release number and survival estimate does account for the different expected survival of parr vs. smolt releases.
+
+For brood years 1998-2011, some of the hatchery-origin fish released included fish from the "captive broodstock" program. In the captive broodstock program, the fish used as broodstock spend their whole lives in the hatchery and never migrate out to the ocean; whereas in the conventional hatchery program, adult fish returning from the ocean are captured to use as brood stock. Whether a fish's parents came from the conventional vs captive broodstock program is known to affect the fish's probability of survival to Lower Granite Dam, but again different survival rates by raceway are accounted for in the aggregate survival point estimates used here.     
+
+## Juvenile: juv-survival-hydro
+
+### Citation
+McCann J, Chockley B, Cooper E, Scheer G, Haeseker S, Lessard B, Copeland T, Ebel J, Storch A, Rawding D, and DeHart, M. 2022. Comparative survival study of PIT-tagged spring/summer/fall Chinook, summer steelhead, and sockeye. 2022 Annual Report, BPA Project #1996-02-00, Fish Passage Center. URL: https://www.fpc.org/documents/Q_fpc_cssreports.php
+
+*Table A1 is pg. 328 in 2023 draft report.*
+
+*Update reference and citations to 2023 report when published*
+
+### Description
+This data set describes annual *survival* probabilities for juvenile natural- and hatchery-origin fish moving downstream through the hydrosystem, from the tailrace of Lower Granite Dam (the first mainstem dam encountered by outmigrants) through the tailrace of Bonneville Dam (the final dam before fish reach the ocean) tailrace. Survival estimates are calculated using a Cormack-Jolly-Seber model based on detections of PIT-tagged fish at the dams, as well as detections at sites downstream (primarily the estuary trawl), detections at bird colonies and other tag recoveries, and adult detections. 
+
+For the GR-LCM, hydrosystem survival estimates are origin-specific (calculated separately for natural-origin vs. hatchery-origin fish), but not population-specific: all populations (of a given origin) are assumed to experience a common survival rate moving through the hydrosystem.   
+
+**Years of data** 
+
+ - natural origin: 27 (migration years 1994-2021)
+ 
+ - hatchery origin: 20 (migration years 2002-2021)
+
+### Source data
+
+Hydrosystem survival estimates are calculated and provided by the Comparative Survival Study [CSS] (McCann et al. 2022). The estimates for natural-origin fish are based on an aggregate of wild fish PIT tagged throughout the Snake River basin (upstream of Lower Granite Dam); this aggregation is necessary in order to get an adequate sample size of PIT-tagged natural-origin fish. The estimates used in the LCM for hatchery-origin fish are based on PIT-tagged hatchery smolt from the Catherine Creek population. (Of the hatchery-supplemented populations modeled by the GR-LCM, only Catherine Creek is included in the Comparative Survival Study.)
+
+Additional details on source data and calculation methods are provided in McCann et al. (2022).
+
+The data values used here were obtained by querying the Fish Passage Center's juvenile survival estimates (https://www.fpc.org/jquerymobile/apps/CSS_Sr_TIR_andD_step1.php;  accessed 2023-09-11) with the following parameters:
+
+- `SPECIES` = Chinook
+
+- `Rear Type` = Hatchery AND Wild 
+
+- `Race Code` = Spring AND Spring_Summer
+
+- `CSS GROUP` = Snake River Wild Spring_Summer Chinook AND Catherine Creek Hatchery Spring Chinook
+
+- `Migration Year` = All Migration Years
+
+
+### Fields
+```{r juv-surv-hydro_fields_tbl}
+
+juv_surv_hydro_fields_tbl <- data.frame(
+  Field = c("mig_year", 	
+            "nat_est",	"nat_lwr90", "nat_upr90",	
+            "hat_est",	"hat_lwr90", "hat_upr90"),
+  Description = c(
+    "Calendar year when the cohort of fish migrated out to the ocean and, thus, the year when the cohort passed downstream through the hydrosystem as juveniles; equivalent to `[brood_year] + 2`.",
+    "Estimated in-river probability of survival from Lower Granite Dam to Bonneville Dam for natural-origin juvenile spring/summer Chinook (Snake River aggregate).",
+    "Lower bound of the 90% confidence interval for the natural-origin survival estimate.", 
+    "Upper bound of the 90% confidence interval for the natural-origin survival estimate.", 
+    "Estimated in-river probability of survival from Lower Granite Dam to Bonneville Dam for hatchery-origin juvenile spring Chinook (Catherine Creek population).",
+    "Lower bound of the 90% confidence interval for the hatchery-origin survival estimate.", 
+    "Upper bound of the 90% confidence interval for the hatchery-origin survival estimate." 
+  )
+)
+
+kable(juv_surv_hydro_fields_tbl) %>%
+  kable_styling(full_width = T, font_size = 10) %>%
+  column_spec(1, bold = T, border_right = T) %>%
+  column_spec(2) #, width = "30em"
+
+```
+
+### Notes and limitations
+The survival estimates being used here are estimated survival probabilities only for fish that moved through the hydrosystem "in river", i.e., the fish that were not transported (from one of the Snake River dams to below Bonneville). The overall proportion of outgoing juvenile Chinook that were transported varies among years. The CSS reports that "[t]ypically for years after 2005 about 40 percent of the PIT-tagged Snake River wild stocks were transported" (McCann et al. 2022). Prior to 2005, the proportion of outmigrating fish that were transported was typically higher, usually in the range of 80% (McCann et al. 2022, Figure 1.6).  The survival of fish that were transported through the hydrosystem is not accounted for in this data set.
+
+The method used to calculate survival estimates in years 2006 and later is different from the method used in earlier years.  This is because the protocol for transport operations at the Snake River Dams changed in 2006, and simultaneously the CSS began using a different method for assigning tagged fish to transport vs. in-river routes through the hydrosystem.  See McCann et al. (2022) for details. 
+
+From McCann et al. 2023: "In 2019, the CSS implemented a new estimation methodology. At that time, we applied this new method to migration years 2006 and later. For this 2023 report, we applied this new methodology to the historic years as well (1994-2005)." However, at the time the GR-LCM was developed and prepared for publication, the revised survival estimates for years 1994-2005 were not yet available on the Fish Passage Center website query, and so the older versions of the survival estimates are used in this `juv-survival-hydro` data set.
+
+Additionally, the published estimates for the most recent migration years (2020, 2021, and 2022) are not yet finalized and may change as the CSS determines final groups for estimation of smolt-to-adult returns.
+
+## Adult: harvest-rates-below-BON
+
+### Citation
+placeholder
+
+### Description
+placeholder
+
+### Fields
+update field descriptions
+```{r harvest_below_BON_tbl}
+
+harvest_below_BON_tbl <- data.frame(
+  Field = c("year", "NOR", "HOR"),
+  Description = c(
+    "Calendar year when adult fish moved upstream through the hydrosystem (i.e., the return year).",
+    "Proportion of the natural-origin adults that ...",
+    "Proportion of hatchery-origin adults that ..."
+  )
+)
+
+kable(harvest_below_BON_tbl) %>%
+  kable_styling(full_width = T, font_size = 10) %>%
+  column_spec(1, bold = T, border_right = T) %>%
+  column_spec(2) #, width = "30em"
+
+```
+
+## Adult: BON-LGR-adult-PIT-detections
+
+### Citation
+Columbia River DART (Data Access in Real Time), Columbia Basin Research, University of Washington. (2023). PIT Tag Adult Returns Conversion Rate. Available from https://www.cbr.washington.edu/dart/query/pitadult_conrate. Accessed 08 Apr 2023.
+
+### Description
+This data set describes a metric of *survival* rate for adults migrating upstream through the hydrosystem (i.e., from Bonneville Dam up to Lower Grante Dam). 
+
+For each year since 2000, the data set gives the number of unique PIT-tagged adult spring/summer Chinook (originating from the Grande Ronde basin) that were detected at Bonneville Dam, and then the subset count of those unique PIT tags that were subsequently detected at Lower Granite Dam. The probability of survival for upstream migrating fish is roughly estimated as the ratio of the number of tags counted at Lower Granite Dam to the number of tags counted at Bonneville (this metric is also known as a "conversion rate"). Survival rates are estimated separately for natural- and hatchery-origin fish. 
+
+Although not a true survival estimate, this simple method still provides a good index of upstream survival rates because the probability of detection at Lower Granite and Bonneville for PIT-tagged adults moving upstream is very high - estimated at over 98% at all dams since 2006 (Crozier et al. 2016). 
+
+For adults returning from the ocean, the probability of detecting PIT-tagged fish as they move upstream past mainstem dams has been near 100%  since the early 2000s (Crozier et al. 2016, or other study?). Therefore the proportion of the PIT-tagged adults detected at Bonneville Dam in a given year that were subsequently detected at Lower Granite Dam can be used as a measure of survival for adults moving upstream through the hydrosystem. This empirical survival rate (known as a “conversion rate” https://www.cbr.washington.edu/dart/query/pitadult_conrate?) integrates all sources of mortality that fish experience during this time, including losses due to harvest, straying, predation, and environmental conditions. 
+
+For the GR-LCM we chose to use this simple, empirical metric of upstream survival rather than attempting to separately quantify rates of mortality and loss due to harvest, straying, predation, environmental conditions, etc. 
+
+### Source data
+PIT tag detection information is maintained by the Columbia Basin PIT Tag Information System (PTAGIS) database.  
+
+PIT tag counts from the dams were provided by the Columbia River Data Access in Real Time (DART) website, [PIT Tag Adult Returns Conversion Rate] (https://www.cbr.washington.edu/dart/query/pitadult_conrate), with the following query parameters:
+
+- `Conversion Reach` = Bonneville to Lower Granite
+
+- `Species` = Chinook
+
+- `Run` = Spring
+
+- `Rear Type` = Wild OR Hatchery
+
+- `Release Location` = Grande Ronde River Basin - All
+
+- `Month Range` = January to December
+
+- `Detections Upstream of Upper Project`: Include
+
+- `Chinook Minijacks`: Exclude
+
+- `Release Sites below Upper Project`: Exclude
+
+- `Transported Fish`: Include (in-river and transport)
+
+**Years of data:** 23 (return years 2000-2022)
+
+### Fields
+```{r adult_surv_hydro_tbl}
+
+adult_surv_hydro_fields_tbl <- data.frame(
+  Field = c("year", "origin",	
+            "BON_adult_detections",	"LGR_adult_detections"),
+  Description = c(
+    "Calendar year when adult fish moved upstream through the hydrosystem (i.e., the return year).",
+    "Natural origin (NOR) vs. hatchery origin (HOR).",
+    "Number of unique PIT-tagged fish (adult spring/summer Chinook originating from the Grande Ronde Basin) detected at Bonneville Dam",
+    "Number of unique PIT-tagged fish (adult spring/summer Chinook originating from the Grande Ronde Basin) detected at Lower Granite Dam. This count only includes detections for the PIT-tagged fish which were first observed at Bonneville."
+  )
+)
+
+kable(adult_surv_hydro_fields_tbl) %>%
+  kable_styling(full_width = T, font_size = 10) %>%
+  column_spec(1, bold = T, border_right = T) %>%
+  column_spec(2) #, width = "30em"
+
+```
+## Adult: adult-abundance
+
+### Citations
+Bliesner, KL, Craft NM, Feldhaus JW, and Ruzycki JR.
+2020. A compendium of Viable Salmonid Population abundance and productivity field and
+analysis methods for natural origin adult Chinook salmon populations in the Snake River Spring/Summer-run ESU of Northeast Oregon from 1949 to 2019. ODFW, East Region Fish Research, La Grande, OR. URL:
+https://nrimp.dfw.state.or.us/DataClearinghouse/default.aspx?p=202&XMLname=1151.xml
+
+Crump C, Naylor L, Van Sickle A, Mathias Z, and Shippentower G. 2019. Monitoring and evaluation of supplemented spring Chinook salmon and life histories of wild summer steelhead in the Grande Ronde basin. Annual Report BPA Project #2007-083-00, Confedrated Tribes of the Umatilla Indian Reservation, Pendleton, OR. URL: https://www.cbfish.org/Document.mvc/Viewer/P164991
+
+Brandt EJ, Smith JD, Feldhaus JW, and Ruzycki JR. 2021. Lower Snake River Compensation Plan: Oregon spring Chinook salmon evaluation studies, 2019 Annual Progress Report. Oregon Department of Fish and Wildlife, La Grande, OR. URL:   https://www.fws.gov/sites/default/files/documents/2019%20ODFW%20CHS%20Annual%20Report.pdf
+
+Kinzer, RN, Arnsberg B, Harbeck J, Maxwell A, Orme R, Rabe C, and Vatland S. 2020. Snake River Basin adult Chinook salmon and steelhead monitoring. 2019 Annual Report. Nez Perce Tribe, Department of Fisheries Resources Management, Research Division. Lapwai, ID. URL: https://www.fws.gov/sites/default/files/documents/2019%20NPT%20Snake%20River%20Basin%20Adult%20Chinook%20Salmon%20and%20Steelhead%20Monitoring.pdf
+
+
+### Description
+*Text in progress*
+
+This data set provides estimates of the annual number (*abundance*) of adult fish that return to the mouth of their natal river. This metric is known as "total return-to-river" (RTR), which is distinct from number of spawners. The total abundance numbers include all adult fish (all ages, both hatchery and natural origin, both female and male); in the GR-LCM, we estimate the *composition* of these returning adults each year based on the weir and carcass data sets. 
+
+Methods for estimating the total RTR are complex and vary according to presence or absence of an adult weir, sample size, and other factors.  The relevant field and analysis methods are described in detail in Bliesner et al. (2020), but some relevant pieces are summarized here. 
+
+Primarily the adult estimation methods depend on the presence or absence of an adult weir. In the three supplemented populations (Catherine Creek, Lostine River, and Upper Grande Ronde River), weirs began operating in 1997. The unsupplemented Minam River population does not have an adult weir.  
+
+For years and populations without an adult weir, the abundance of returning adults is estimated based on expansions from redd counts. Redd counts are either assumed to be a census or counts are expanded to account for unsurveyed space or time.  Then the total number of redds is expanded by a standard value of 3.2 spawners per redd (2.23 in Catherine Creek), which was derived from ....  Finally, this estimated number of spawners is expanded by the estimated rate of prespawn survival in order to calculate the total number of fish in the river prior to prespawn mortality. Prespawn survival is estimated by ...
+
+For years and populations with an adult weir, abundance or 
+the primary estimate of abundance is usually based on a mark-recapture estimate of the number of adult fish above the weir: fish that are handled at the weir are marked with an opercle punch[es] before being released upstream to spawn naturally, and then carcasses recovered during spawning ground surveys are checked for presence or absence of the opercle punch marking. However the full RTR estimate incorporates numerous components. The abundance of age-3 fish ("jacks") is estimated separately from the abundance of age-4 and age-5 fish, because jacks tend to differ in probability of being handled at the weir and probability of recovery on the spawning grounds. In general, abundance estimates for the age-3 fish are substantially more problematic and more uncertain than the age-4/5 abundance estimates. ] 
+
+- First, abundance of age 4/5 fish in the river above the weir is estimated, usually based on a mark-recapture estimate from fish marked at the weir and recovered as carcasses on the spawning grounds. 
+
+- Then, abundance of age-3 fish is estimated based on a variety of methods. If there are enough recoveries of age-3 carcasses (this is rare), then the mark-recapture method is preferred. 
+
+  + In some cases there are not enough carcass recoveries to allow for a mark-recapture abundance estimate of age-4/5 fish - this is especially common for the Upper Grande Ronde population.
+  
+**general outline**
+
+- redd-based vs weir-based estimates
+
+- adult vs jack estimation methods
+
+- logic of weir removals, tributary harvest, prespawn mortality.
+
+- estimation of uncertainty values
+
+- years of data
+
+- Notes/limitations
+  - adults are indexed by return year not brood year
+
+```{r adult_abund_fields_tbl}
+
+adult_abund_fields_tbl <- data.frame(
+  Field = c("population", "return_year", "n_returned", "n_above_weir", "abund_cv"),
+  Description = c(
+    "`CAT` = Catherine Creek; `LOS` = Lostine River; `MIN` = Minam River; `UGR` = Upper Grande Ronde River.", 
+    "Calendar year when adult fish returned to freshwater and attempted to spawn.",
+    "Estimated number of adult fish that returned to the mouth of their natal river (i.e., Catherine Creek, Lostine River, Minam River, or Upper Grande Ronde River), before any losses to tributary harvest, removals at the weir, or prespawn mortality. This number includes all ages, origins, and sexes.",
+    "Estimated number of fish in the river above the weir, after removals at the weir and after any tributary harvest, but prior to any prespawn mortality. Note that some fish may spawn below the weir, without ever being handled at the weir; these fish are not counted in the `[n_above_weir]` value. For years and populations where no adult weir is present, `[n_above_weir]` is equal to `[n_returned]`.",
+    "Estimated uncertainty of the `[n_returned]` values, expressed as a coefficient of variation."
+  )
+)
+
+kable(adult_abund_fields_tbl) %>%
+  kable_styling(full_width = T, font_size = 10) %>%
+  column_spec(1, bold = T, border_right = T) %>%
+  column_spec(2) #, width = "30em"
+
+```
+
+### Notes and limitations
+placeholder
+
+## Adult: tributary-harvest
+
+### Citation
+Bratcher KW, Yanke JA, Bailey TD. 2017. Lower Snake River Compensation Plan: Oregon Spring Chinook Salmon Harvest Monitoring, 2016 Annual Progress Report. Oregon Department of Fish and Wildlife, Grande Ronde Watershed, East Region. URL: https://www.fws.gov/sites/default/files/documents/2016%20ODFW%20Spring%20Chinook%20Harvest.pdf
+
+### Description
+This auxiliary data set reports the numbers of adult fish, by origin, sex, and age, that were harvested (i.e., removed from the spawning population) after they returned to their natal river.  "Tributary harvest" is distinguished from harvest that occurs while fish are still in the ocean or while they are migrating upstream through the mainstem Columbia and Snake Rivers. (In the LCM, these other forms of harvest are captured in the `harvest-rates-below-BON` and `BON-LGR-adult-PIT-detections` data sets, as well as in the ocean survival and maturity rates estimated within the model.) Within the GR-LCM these tributary harvest counts are treated as known values without associated sampling error.  
+
+Of the populations and years modeled by the LCM, only the Lostine population experiences regular tributary harvest, although even in Lostine there have been numerous years with very low or zero tributary harvest.  For the Catherine Creek population, tributary harvest occurred only in 2021, and for the Upper Grande Ronde population tributary harvest occurred in a few years (2010 and 2014-2017). There is no tributary harvest in the Minam population. None of the populations modeled by the LCM had any recorded tributary harvest during the mostly low-return years 1986-2000. 
+
+This data set reports only positive harvest counts; harvest for any populations, years, and/or compositions not included in the data set is assumed to be zero.
+
+Tributary harvest comprises both sport (recreational) and tribal fisheries.  Sport fisheries target only hatchery-origin fish (although there may be incidental angling-related mortality of natural-origin fish), while tribal fisheries are non-selective by fish origin. Tribal nations (Nez Perce Tribe and the Confederated Tribes of the Umatilla Indian Reservation) monitor and report their annual tribal fishery harvest numbers. Sport fishery harvest numbers are estimated based on creel surveys; method details are provided in Bratcher *et al.* (2017). 
+
+### Fields
+
+```{r adult_trib_harvest_fields_tbl}
+
+trib_harvest_fields_tbl <- data.frame(
+  Field = c("population", "year",		
+            "origin", "sex", "age", "count"),
+  Description = c(
+    "`CAT` = Catherine Creek; `LOS` = Lostine River; `MIN` = Minam River; `UGR` = Upper Grande Ronde River.", 
+    "Calendar year when the fish was harvested, i.e., return year for the adult fish.",
+    "`Nat` = natural origin (the fish's parents spawned naturally); `Hat` = hatchery origin (the fish's parents were spawned in a hatchery).",
+    "`F` = Female; `M` = Male.",
+    "Age of the fish (age-3, age-4, or age-5), according to best available estimate.",
+    "Number of fish harvested."
+  )
+)
+
+kable(trib_harvest_fields_tbl) %>%
+  kable_styling(full_width = T, font_size = 10) %>%
+  column_spec(1, bold = T, border_right = T) %>%
+  column_spec(2) #, width = "30em"
+
+```
+
+### Notes and limitations
+Estimates of tributary harvest (most often zero) are available for all years and populations modeled by the LCM, so there are no missing data. 
+
+Although harvest numbers are treated as known values in the LCM, in practice there is substantial uncertainty associated with these estimates.  The sport harvest estimates are based on statistical expansions from creel survey data, which may represent a small sample size relative to the total harvest.  The age compositition of the tributary harvest is particularly uncertain, because of the uncertainty in assigning ages to individual fish in most cases (see discussion in the documentation for the `adult-indiv-weir` data set) as well as the uncertainty due to sampling variability.  
+
+## Adult: adult-indiv-weir
+
+### Citations
+Crump C, Naylor L, Van Sickle A, Mathias Z, and Shippentower G. 2019. Monitoring and evaluation of supplemented spring Chinook salmon and life histories of wild summer steelhead in the Grande Ronde basin. Annual Report BPA Project #2007-083-00, Confedrated Tribes of the Umatilla Indian Reservation, Pendleton, OR. URL: https://www.cbfish.org/Document.mvc/Viewer/P164991
+
+Brandt EJ, Smith JD, Feldhaus JW, and Ruzycki JR. 2021. Lower Snake River Compensation Plan: Oregon spring Chinook salmon evaluation studies, 2019 Annual Progress Report. Oregon Department of Fish and Wildlife, La Grande, OR. URL:   https://www.fws.gov/sites/default/files/documents/2019%20ODFW%20CHS%20Annual%20Report.pdf
+
+Kinzer, RN, Arnsberg B, Harbeck J, Maxwell A, Orme R, Rabe C, and Vatland S. 2020. Snake River Basin adult Chinook salmon and steelhead monitoring. 2019 Annual Report. Nez Perce Tribe, Department of Fisheries Resources Management, Research Division. Lapwai, ID. URL: https://www.fws.gov/sites/default/files/documents/2019%20NPT%20Snake%20River%20Basin%20Adult%20Chinook%20Salmon%20and%20Steelhead%20Monitoring.pdf
+
+### Description
+This data set provides raw data on individual adult fish captured and handled at the adult weirs on Catherine Creek (`CAT` population), the Lostine River (`LOS` population), and the Upper Grande Ronde River (`UGR` population). There is no adult weir on the Minam River (`MIN` population). The Lostine River weir is operated by the Nez Perce Tribe (NPT), and the Catherine Creek and Upper Grande Ronde weirs are operated by the Confederated Tribes of the Umatilla Indian Reservation (CTUIR). 
+
+In the GR-LCM we used this data set to estimate *composition* of the returning adults each year, in terms of age and origin. We also used this data set to count the numbers of fish removed at the weir, by age and origin; these counts are assumed to be known without error. 
+
+In general, data collected for each fish handled at the weir include length, sex, origin, and age. Most records describe individual fish (`[count]` = 1), but there are some cases where a single record is used to describe a group of fish. Sex is identified (as best as possible) from morphological characteristics. Origin is determined based on presence or absence of an adipose fin clip and presence or absence of a coded wire tag (CWT). Methods for determining or estimating the age of a fish vary depending on what information is available. In order of preference, age is determined from parental-based-tagging (i.e., genetic data); recovery of a coded wire tag; scanning an existing PIT tag (for fish that were tagged as juveniles); reading a scale sample; or estimated based on length using a year- and population-specific age-length key. For most weir records the best age value has already been identified (in the `[best_age]` field), but there were some instances where a fish had no assigned `[best_age]` but did have a value for one of the other age fields; in this situation, for the LCM we used one of the other available age values (if any), according to the preferred order. 
+
+Although in general hatchery origin can be identified from an adipose fin clip, plus, often, the presence of a CWT, origin assignment is more challenging for the UGR population. Only about 50% of the hatchery-origin smolt released into UGR each year have adipose fin clips (the rate is near 100% for the other populations). Instead the hatchery smolt are all supposed to be marked with CWT, but in practice these CWT are not always present or always detectable in returning adults (presumably due to tag loss). In recent years, genetic sample collection from all fish spawned at the hatchery has enabled definitive origin assignment for many of the adult fish collected for broodstock at the UGR weir. These genetic data show that a fairly consistent ~10% of the adult fish assigned "Natural" origin when they were collected at the UGR weir are, in fact, hatchery origin (based on matching their genetic samples to known parents from hatchery spawning; ODFW, unpublished data). This same pattern of true hatchery-origin fish being assigned natural origin is not seen in the Lostine or Catherine Creek populations (which have similar genetic data availability), presumably because those populations have near-100% adipose clips for hatchery smolt. In order to account for this known bias in origin assignment in the UGR weir data, for the GR-LCM we applied a simple correction factor: for return years 2006 and later (corresponding to the time period when the adipose-clip rate for hatchery smolt settled at or near 50%), we assumed that 10% of the fish assigned "Natural" origin at the UGR weir were actually Hatchery origin, and the origin composition for each 2006+ return year is revised accordingly in the model. (We did not apply any origin correction to the CAT or LOS populations.)    
+
+The adult weirs are intended to operate continuously throughout the run of adult fish, but in some cases high water temperatures (especially at the Upper Grande Ronde weir) necessitate removing the weir while fish are still moving. High flows can also damage or disable weirs. The overall efficiency of the adult weir varies among populations and among years, but weir counts are never assumed to be a census of all fish on the spawning grounds above the weir. Additionally, to varying degrees among populations, some fish spawn downstream before ever arriving at the weir. 
+
+For the GR-LCM we classified all fish arriving at the weir as either *removed* from the population or *passed* upstream (i.e., returned to the river) to attempt to spawn naturally.  Fish are removed at the weir for a variety of reasons (including outplants for additional harvest opportunity and limiting the numbers of hatchery-origin fish on the spawning grounds), but the primary reason is to collect broodstock for spawning in the hatchery. The distinction between *removed* vs. *passed* is more complicated for the Lostine population: some adults arriving at the Lostine weir are "outplanted" down to the lower Wallowa River (downstream of the Lostine weir) to provide additional harvest opportunity.  However, in the weir data set provided here, these lower Wallowa outplants are classified as *passed* because they may (if not havested) return to the Lostine River and spawn there, meaning that for the accounting used within the GR-LCM these individuals remain within the population of potential spawners. (Fish that are removed through the lower Wallowa "tributary" harvest are accounted for in the `tributary-harvest` data set.)
+
+Some individual fish are handled at the weir more than once: this occurs when, for example, a fish outplanted downstream swims back up to the weir, or when a fish passed upstream "falls back" below the weir and then is recaptured. These recaptures can be identified by the presence of an opercle mark(s), and all recapture records are indicated in the data set with `[recapture] = TRUE`. In the GR-LCM, we excluded all recaptures from the composition estimation, to ensure that each individual was counted only once. However, we did include recaptures in the counts of fish removed at the weir. 
+
+**Years of data:** 26 (RY 1998 - 2022)
+
+- CAT: 25 years (RY 1998-2022)
+
+- LOS: 18 years (RY 1997-2022; missing RY 2001-2008)
+
+- MIN: 0 years *(No weir in the Minam population)*
+
+- UGR: 25 years (RY 1998-2022)
+
+### Fields
+
+```{r adult_weir_fields_tbl}
+
+adult_weir_fields_tbl <- data.frame(
+  Field = c("population", "trapyear",		
+            "count","sex", "origin", "fork_length", "disposition",
+            "agedesignation", "age_best", "age_cwt", "age_pit", "age_scale", "age_length",
+            "recapture", "oppunch", "notes"),
+  Description = c(
+    "`CAT` = Catherine Creek; `LOS` = Lostine River; `MIN` = Minam River; `UGR` = Upper Grande Ronde River.", 
+    "Calendar year when the fish was trapped, i.e., return year for the adult fish.",
+    "Number of fish described by the record. Most records describe individual fish, but there are some instances of more than one fish per record.",
+    "`F` = Female; `M` = Male; `Unk` = Unknown.",
+    "`Nat` = natural origin (the fish's parents spawned naturally); `Hat` = hatchery origin (the fish's parents were spawned in a hatchery).",
+    "Fork length (mm).",
+    "Describes what happened to the fish after it was handled. `Passed` = fish was returned to the river and allowed to spawn naturally; usually this means passed above the weir, but in some cases fish may be passed downstream of the weir. `Removed` = the fish was removed from the potential spawning population.",
+    "`Adult` (in this context) = a fish presumed to be age-4 or age-5; `Jack` = a fish presumed to be age-3 (based on size); `Unk` = Unknown.",
+    "Best available age estimate (generally age 3, 4, or 5) for the fish. ",
+    "Age determination based on a recovered coded wire tag.",
+    "Age determination based on information from an existing PIT tag (for fish tagged as juveniles).", 
+    "Age estimate based on reading a scale sample.",
+    "Age estimate based on a year- and population-specific age-length key.",
+    "`TRUE` = the fish had been previously handled (and marked) at the weir, i.e., this is not the first time the fish was captured; `FALSE` = the fish had not been previously captured at the weir, i.e., this record represents the first capture event for the fish.", 
+    "Codes indicating the number and site (Right or Left) of opercle markings applied to the fish.", 
+    "Any recorded comments."
+  )
+)
+
+kable(adult_weir_fields_tbl) %>%
+  kable_styling(full_width = T, font_size = 10) %>%
+  column_spec(1, bold = T, border_right = T) %>%
+  column_spec(2) #, width = "30em"
+
+```
+
+### Notes and limitations
+In the GR-LCM we assumed that fish trapped at the weir provide an unbiased sample of the full population of returning adult fish. However, the weirs are known to be less efficient at catching age-3 fish than they are at catching age-4 and age-5 fish (ODFW, unpublished data), meaning that the proportion of age-3 fish in the returning population is likely underestimated. Other effects of missing a portion of the run? 
+
+We also assumed that the recorded age and origin values are known without error. In practice, however, both are subject to error - especially age. Parental-based-tagging, CWT recovery, and some PIT tag records provide known age, but all other age assignments are estimates based on scale reading or age-length keys. For origin, identifying hatchery origin usually relies on presence of an adipose fin clip and/or a CWT, and these indicators are not always present in true hatchery-origin fish (especially for the UGR population, as described above).    
+
+Although the weirs all began operating in 1997 or 1998, these initial years experienced low trap efficiency and caught very few fish. But all traps were running effectively by the early 2000s. 
+
+Data collection at the Lostine weir in 2001-2008 was problematic, and in the GR-LCM we excluded these years of data from the composition estimates (composition for the Lostine population in these years was estimated based only on carcass recoveries, as for the Minam population). However, we did use these 2001-2008 data to tally fish removed at the weir.   
+
+## Adult: adult-indiv-carcass
+
+### Citations
+Crump C, Naylor L, Van Sickle A, Mathias Z, and Shippentower G. 2019. Monitoring and evaluation of supplemented spring Chinook salmon and life histories of wild summer steelhead in the Grande Ronde basin. Annual Report BPA Project #2007-083-00, Confedrated Tribes of the Umatilla Indian Reservation, Pendleton, OR. URL: https://www.cbfish.org/Document.mvc/Viewer/P164991
+
+Brandt EJ, Smith JD, Feldhaus JW, and Ruzycki JR. 2021. Lower Snake River Compensation Plan: Oregon spring Chinook salmon evaluation studies, 2019 Annual Progress Report. Oregon Department of Fish and Wildlife, La Grande, OR. URL:   https://www.fws.gov/sites/default/files/documents/2019%20ODFW%20CHS%20Annual%20Report.pdf
+
+Kinzer, RN, Arnsberg B, Harbeck J, Maxwell A, Orme R, Rabe C, and Vatland S. 2020. Snake River Basin adult Chinook salmon and steelhead monitoring. 2019 Annual Report. Nez Perce Tribe, Department of Fisheries Resources Management, Research Division. Lapwai, ID. URL: https://www.fws.gov/sites/default/files/documents/2019%20NPT%20Snake%20River%20Basin%20Adult%20Chinook%20Salmon%20and%20Steelhead%20Monitoring.pdf
+
+### Description
+This data sets provides raw data on individual adult fish, collected from recovered adult carcasses during spawning ground surveys. In the GR-LCM, both carcass data and weir data are used to estimate the composition (in terms of age and origin) of the population of returning adult fish in each return year. Through estimated age, returning adult fish can be assigned back to their brood year of origin. 
+
+This same carcass data set was also used to generate the pre-spawn survival estimates (see notes for the `prespawn-survival` data set). 
+
+Chinook spawning ground surveys in the Grande Ronde Basin are funded by the Lower Snake River Compensation Plan and conducted by co-managers CTUIR, NPT, and ODFW.
+
+For populations that have an adult weir, many of the carcasses recovered during spawning ground surveys are fish that were previously handled and documented at the weir (before being released back to the river to spawn naturally). Fish that were previously handled at the weir can be identified by an opercle punch marking, but there is no way to definitively match individual marked carcasses back to their corresponding individual record in the weir data. The numbers of marked vs. unmarked carcasses recovered  during spawning ground surveys are used for the mark-recapture estimation of fish abundance above the weir (see notes for the `adult-abundance` data set). 
+
+For all carcass recoveries, surveyors attempt to collect data on fork length; sex; origin (based on presence or absence of an adipose fin clip and/or CWT); spawn status (for females); and presence or absence of opercle punch markings. However, the condition of the carcass determines what information can be collected (for example, if the carcass's tail has been eaten by a scavenger then fork length cannot be measured), meaning that many carcass records have missing data.  
+
+As in the weir data set, a variety of different sources of information are used to determine or estimate the age of a fish, and the best available information source for each fish is used to assign an age to that fish.  In order of preference, these methods include parental-based tagging (PBT; i.e., genetic identification of parents and thus of brood year); coded wire tag recovery (CWT; hatchery fish only); PIT tag (for fish tagged as juveniles); fin ray or scale reading; or age-length key. Age determinations based on PBT, CWT, or PIT tag are essentially known without error, while age assignments based on scale reading or age-length keys are "best guess" aging. 
+
+**Years of data:** 32 (RY 1991 - 2022; no carcasses recovered from the UGR population in 1994 or 1999)
+
+### Fields 
+```{r adult_carcass_fields_tbl}
+
+adult_carcass_fields_tbl <- data.frame(
+  Field = c("population", "year",		
+            "sex", "origin", "fork_length", 
+            "age_best", "age_cwt", "age_scale", "age_key", "age_length", "prespawn"),
+  Description = c(
+    "`CAT` = Catherine Creek; `LOS` = Lostine River; `MIN` = Minam River; `UGR` = Upper Grande Ronde River.", 
+    "Calendar year when the carcass was recovered, i.e., return year for the adult fish.",
+    "`F` = Female; `M` = Male; `Unk` = Unknown. Sex of carcasses can usually be determined with high confidence by cutting open the body cavity.",
+    "`Nat` = natural origin (the fish's parents spawned naturally); `Hat` = hatchery origin (the fish's parents were spawned in a hatchery). Origin is determined based on presence or absence of an adipose fin clip and presence or absence of a coded wire tag, but predation and decay of carcasses may destroy these indicators.",
+    "Fork length (mm), if known.  Many carcasses are not measurable (e.g., only the head was found).",
+    "Best available age estimate (generally age 3, 4, or 5) for the fish. Methods of determining age are, in order of preference, parental-based-tagging; coded wire tag; PIT tag; scale read; age-length key; and simple length bins. In some cases a fish may have a value for one of the other age fields but no assigned `[best_age]`, in which case the GR-LCM will use one of the other available age values (if any), according to the preferred order.",
+    "Age estimate based on a recovered coded wire tag.",
+    "Age estimate based on reading a scale sample.",
+    "Age estimate based on a year- and population-specific age-length key.",
+    "Age estimate based on simple fork length bins.",
+    "For female carcasses, did the fish spawn successfully (`Spawned`), or did the fish die before spawning (`PreSpawn`)? Fish are considered `Spawned` if there are no more than #% of eggs remaining. This field is `NA` when `[Sex]` = `M`or `Unk`."
+  )
+)
+
+kable(adult_carcass_fields_tbl) %>%
+  kable_styling(full_width = T, font_size = 10) %>%
+  column_spec(1, bold = T, border_right = T) %>%
+  column_spec(2) #, width = "30em"
+
+```
+
+### Notes and limitations
+Carcass collection is limited by when spawning ground surveys occurred in a given year and population. Sometimes planned surveys have to be skipped due to (for example) wildfire or a landowner denying permission to access the site.  Most spawning reaches are surveyed multiple times during the spawning season, and carcasses are more likey to be recovered during the late surveys, when a majority of fish have completed spawning. If the last survey of a reach is skipped, then this will likely result in missing most of the carcass recovery opporutniLate surveys are more likely to have carcasses. 
+
+Some populations have much higher carcass recovery probabilities than others. Wilderness streams - i.e., the Minam River, among the GR-LCM populations - tend to have very low carcass recovery probabilities, presumably due to relatively higher abundances of scavengers. Carcass recovery probability is also very low on the Upper Grande Ronde River, due to a combination of heavy scavenger pressure and (in most years) low numbers of fish (ODFW, unpublished data).  
+
+Carcass recovery probability is biased by fish size and sex. Larger fish are more likely to be recovered than smaller fish, and recoveries of age-3 ("jacks") carcasses are especially rare, relative to recoveries of age-4 and age-5 carcasses (Murdoch et al. 2010; Zhou 2002; ODFW, unpublished data).  Additionally, females are more likely to be recovered than males, presumably due to behavioral differences: females are likely to die at or very near their redd, and those locations will be observed most closely by surveyors (Murdoch et al. 2010; ODFW, unpublished data). 
+
+In the GR-LCM, we corrected for biased carcass recovery probabilities when using carcass data to estimate sex and age composition of returning adult fish.   
+
+## Adult: prespawn-surv
+
+### Citation
+See `adult-indiv-carcass` data set. 
+
+### Description
+This auxiliary data set provides estimated rates of prespawn survival for each population and return year modeled by the GR-LCM. We fit a binomial model predicting prespawn survival in each population and return year based on observed spawn status in carcass recoveries, and then supplied the estimated prespawn survival rates to the GR-LCM as known values. The source data for the prespawn survival model was the `adult-indiv-carcass` data set.
+
+"Prespawn survival" here describes the probability of survival from the time that potential spawning begins to successful spawning. 
+
+Rates of prespawn survival are estimated based on observed spawn status of carcass recoveries. For all female carcasses recovered, surveyors attempt to determine whether the fish spawned successfully (few eggs remain) vs. the fish died befored spawning (large number of eggs still in the body cavity). The relative numbers of successfully spawned vs. unspawned carcasses can be used to roughly estimate the rate of prespawn mortality (or, equivalently, prespawn survival) in a given population and return year. However, in many years the numbers of eligible carcasses recovered are very low - primarily in the UGR and Minam populations - which does not allow for robust estimation of an overall prespawn survival rate using just that year's carcass recoveries.
+
+Analysis of the existing carcass recovery data indicated that there are some consistent differences among populations in prespawn survival rates: survival tends to be higher in the MIN and CAT populations, and lower in the LOS and, especially, UGR populations. There is also some evidence that prespawn survival for a given population varies among years, at least in the UGR population. Other studies have found increased rates of prespawn mortality associated with higher mean stream temperatures during the spawning period (Bowerman et al. 2021), which may drive some of the observed variability in prespawn survival rates among years.  
+
+For the GR-LCM, we used the carcass recovery data as described above to fit population-specific logistic mixed models assuming a time constant mean with logit-normal annual random effects. 
+
+### Fields
+```{r adult_prespawn_surv_fields_tbl}
+
+prespawn_surv_fields_tbl <- data.frame(
+  Field = c("brood_year", "population",		
+            "prespawn_surv"),
+  Description = c("Here equivalent to [Return Year]: the year adults SPAWNED, NOT the year they WERE SPAWNED. This nomenclature is used to allow merging with other data sets.",
+    "`CAT` = Catherine Creek; `LOS` = Lostine River; `MIN` = Minam River; `UGR` = Upper Grande Ronde River.", 
+    "Probability that an adult female fish survives from the beginning of the spawning period to successful spawning."
+  )
+)
+
+kable(prespawn_surv_fields_tbl) %>%
+  kable_styling(full_width = T, font_size = 10) %>%
+  column_spec(1, bold = T, border_right = T) %>%
+  column_spec(2) #, width = "30em"
+
+```
+
+### Notes and limitations
+
+The terms "prespawn survival" or "prespawn mortality" can be used to describe survival over a range of different time periods in adult salmonid life history. At its broadest, the term can refer to "non-fishery mortality of adult salmon and steelhead between the time the fish enter the Columbia River and the completion of spawning" (Johnson et al. 2007). More commonly, it refers to mortality between returning to the spawning area (i.e., after completing migration) and successful spawning (Bowerman et al. 2018). But, because in this data set the spawning ground surveys where carcasses might be recovered typically occur only during the spawning period, in practice the sampling method captures only mortality during this brief time period (about three weeks).  Bowerman et al. (2021) describe this distinction as the "holding period" (after adults have returned to the spawning area and completed migration but before the initiation of spawning) vs. the "spawning period".  
+
+For the GR-LCM, mortality between Bonneville Dam and Lower Granite Dam is captured in the `BON-LGR-adult-PIT-detections` "converstion rate" data set; and mortality during the spawning period is captured in the pre-spawn survival data set; but adult mortality between Lower Granite Dam, arriving on the spawning grounds, and holding until spawning begins, is not captured in the data sets used to fit the GR-LCM.
+
+Low sample sizes of recovered carcasses with known spawn status in many years and populations limit our ability to make strong inferences about prespawn mortaltiy rates. This is especially problematic for the Upper Grande Ronde population, where carcass recoveries are consistently very low (due to a combination of low adult fish numbers and low recovery rates), but the available evidence (including some data from radio-tracking returning adults; Crump et al. 2021) suggests that prespawn survival rates in this population are both low and highly variable among years.  So we have only limited information available to describe this important source of mortality in the UGR population.  Carcass recovery rates also tend to be low in the Minam population, but prespawn survival rates there tend to be high and consistent among years.   
+
+## Adult: fecundity
+
+### Citation
+Oregon Department of Fish and Wildlife, unpublished data.
+
+### Description
+This auxiliary data set provides values for the expected fecundity (eggs produced per female) for returning adult fish by age (age-4 vs. age-5), population, and year. In the GR-LCM, fecundity is treated as a known value. 
+
+Extensive data on fecundity of Chinook in the Grande Ronde Basin are available through the records from hatchery spawning, where ~30-80 female fish from each of the CAT, LOS, and UGR populations are spawned in the hatchery each year (beginning in 2001), and the fecundity of each female spawned is measured (using an automatic egg counter) and recorded. After hatch, egg counts are validated against auto-trailer counts of juveniles in each hatchery raceway. 
+
+For the GR-LCM, we used mean length of returning adult females (by age, population, and year) to predict mean fecundity for each year and population. Expected fecundity of a given fish is strongly related to fish size: larger fish produce more eggs (ODFW, unpublished data). Because fish size is related to fish age, age can be used as a simple categorical predictor of fecundity. In development of the GR-LCM, however, there was some concern that using static age-based estimates for fecundity could obscure differences among populations in mean size-at-age, or changes in size-at-age over time. 
+
+In order to estimate year- and population-specific fecundity values for the GR-LCM, we first used all available hatchery spawning records from the GR-LCM populations to fit a linear model predicting individual fecundity as a function of fork length. Then we used all available weir and carcass records to calculate the mean length of returning females in each year and population, by age (age-4 and age-5).  Finally, we used these mean length values in the linear model to predict mean fecundity for each age, year, and population. Although it would have been simpler to use the spawning data directly to estimate mean fecundity by age in each year and population, there were too many missing data points to make this approach viable for the GR-LCM: hatchery spawning records do not start until 2001, while the model extends back to 1991. Additionally, there are no spawning data for Minam population, because there is no hatchery supplementation in this population.  Calculating fecundity based on mean length allowed us to extend the population- and year-specific fecundity estimates out to these years and populations for which there is no direct spawning data. 
+
+### Fields
+
+```{r adult_fecundity_fields_tbl}
+
+fecundity_fields_tbl <- data.frame(
+  Field = c("population", "year",		
+            "age", "n_lengths", "mean_length", "fecundity"),
+  Description = c(
+    "`CAT` = Catherine Creek; `LOS` = Lostine River; `MIN` = Minam River; `UGR` = Upper Grande Ronde River.", 
+    "Calendar year when the fish spawned, i.e., return year for the adult fish.",
+    "Age of fish (age-4 or age-5) for which fecundity is being estimated.",
+    "Number of length values used to calculate the [mean_length] value.",
+    "Mean length (fork length in mm) of returning adult females. In many cases mean lengths were calculated by pooling populations and/or return years; see notes below.",
+    "Predicted number of eggs produced per spawning female."
+  )
+)
+
+kable(fecundity_fields_tbl) %>%
+  kable_styling(full_width = T, font_size = 10) %>%
+  column_spec(1, bold = T, border_right = T) %>%
+  column_spec(2) #, width = "30em"
+
+```
+
+### Notes and limitations
+Age-3 females are rare (almost all fish that return at age-3 are males), and this life history pathway is excluded from the GR-LCM. Therefore we calculated fecundity estimates for age-4 and age-5 females only.  
+
+Calculating mean length of returning adult females by age, year, and population was limited by small sample sizes in some years and populations. This is especially true for age-5 fish; in the years modeled by the GR-LCM age-4 fish are always more common than age-5. In order to ensure adequate sample sizes for robust estimation of mean length, we pooled some populations and years together for calculating means:
+
+- The CAT, UGR, and MIN population length (by age) values were all pooled together, within each return year. 
+    + The UGR population usually has very few carcass recoveries, and often very low numbers of returning adults at all, resulting in small sample sizes for length in most years.  We pooled UGR fish with CAT fish for estimating mean length, because existing data for CAT and UGR show very similar length-at-age data among the two populations. The two populations (CAT and UGR) are also relatively close to one another geographically. 
+    
+    + The MIN population also has consistently low sample sizes (with no weir in this population, the only length data come from carcass recoveries, which are rare in the Minam). We initially thought to pool the Minam population with the Lostine for the mean length estimation, but examination of the available length data showed that Minam lengths tended to be closer to the CAT and UGR populations than to the LOS population.  Therefore, the MIN, UGR, and CAT populations were all pooled together, while LOS lengths were estimated separately.  Lostine fish tend to be larger (for a given age) than fish from the other three populations. 
+
+- The years 1991-2000 had consistently low sample sizes across all populations, especially for age-5 fish. This was due to a combination of no weir data for 1991-1996 (and limited data from the early years of weir operation), plus just very low fish return numbers overall during the 1990s. Therefore years 1991-2000 were pooled together (within each population) for estimating mean length at age. 
+
+## {-}
+
+# References
+
+Bowerman TE, Roumasset A, Keefer ML, Sharpe CS, and Caudill CC. 2018. Prespawn mortality of female Chinook salmon increases with water temperature and percent hatchery origin. Transactions of the American Fisheries Society 147(1): 31-42. 
+
+Bowerman TE, Keefer ML, and Caudill CC. 2021. Elevated stream temperature, origin, and individual size influence Chinook salmon prespawn mortality across the Colubia River Basin. Fisheries Research 237: 105874. 
+
+Crozier L, Dorfmeier E, Marsh T, Sandford B, and Widener D. 2016. Refining our understanding of early and late migration of adult Upper Columbia spring and Snake River spring/summer Chinook salmon: passage timing, travel time, fallback
+and survival. Fish Ecology Division, Northwest Fisheries Science Center, National Marine Fisheries Service, Seattle, WA. URL: https://www.webapps.nwfsc.noaa.gov/assets/11/9043_02102017_113115_Crozier%20et%20al%202016%20Chinook%20adult%20mig%20timing%20survival-Mar08_2016.pdf
+
+Crump C, Naylor L, Van Sickle A, Mathias Z, Kennedy J, McLean M, Seeger R, and Shippentower G. 2021. CTUIR Chinook Radio Tracking Update: A presentation for the Grande Ronde Model Watershed State of the Sciences Meeting, November 2021.
+
+Duarte A and Peterson J. 2020. Generalized additive model penalized p-spline trap estimator. Beta version 2.0, revised May 2021. Oregon Cooperative Fish and Wildlife Research Unit.
+
+Johnson DH, Shrier BM, O'Neal JS, Knutzen JA, Augerot X, O'Neil TA, and Pearsons TN. 2007. Salmonid field protocols handbook: techniques for assessing status and trends in salmon and trout populations. American Fisheries Society, Bethesda, Maryland.
+
+Murdoch AR, Pearsons TN, and Maitland TW. 2010. Estimating the spawning escapement of hatchery- and natural-origin spring Chinook salmon using redd and carcass data. North American Journal of Fisheries Management 30(2): 361–375.
+
+Thedinga JF, Murphy ML, Johnson SW, Lorenz M, and Koski KV. 1994. Determination of salmonid smolt yield with rotary screw traps in the Situk River, Alaska, to predict effects of glacial flooding. North American Journal of Fisheries Management 14(4): 837-851.
+
+Volkhardt GC, Johnson SL, Miller BA, Nickelson TE, and Seiler DE. 2007. Rotary screw traps and inclined plane screen traps. Pages 235-266 in Johnson DH, Shrier BM, O'Neal JS, Knutzen JA, Augerot X, O'Neil TA, and Pearsons TN. Salmonid field protocols handbook: techniques for assessing status and trends in salmon and trout populations. American Fisheries Society, Bethesda, Maryland. 
+
+Zhou S. 2002. Size‐dependent recovery of Chinook salmon in carcass surveys. Transactions of the American Fisheries Society 131(6): 1194–1202. https://doi.org/10.1577/1548-8659(2002)131<1194:SDROCS>2.0.CO;2


### PR DESCRIPTION
Add .rmd file with full documentation for all the data sets (almost) used in the GR-LCM. The document is not totally complete - the sections for adult-abundance and harvest-rates-below-BON - still need to be finished. But adding to the repo now so that the information is available to all collaborators during manuscript preparation and review. 